### PR TITLE
Fixed #7

### DIFF
--- a/url.js
+++ b/url.js
@@ -359,7 +359,7 @@ Url.prototype.paths = function(paths) {
     var i = 0;
     var s;
 
-    if (paths && paths.length && paths + "" != paths) {
+    if (paths && paths.length) {
         if (this.isAbsolute()) {
             prefix = "/";
         }


### PR DESCRIPTION
Eredetelig `!==` check volt, ami sosem értékelődik ki, mivel mindig igaz, ehelyett írtam hibásan `!=`-t javításnál, ahelyett, hogy kitöröltem volna.